### PR TITLE
Fixes awusb Makefile

### DIFF
--- a/awusb/Makefile
+++ b/awusb/Makefile
@@ -3,8 +3,7 @@ KDIR := /lib/modules/$(shell uname -r)/build
 PWD := $(shell pwd)
 
 default:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
 clean:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) clean
-	rm -rf Module.markers module.order module.sysvers 
-	
+	$(MAKE) -C $(KDIR) M=$(PWD) clean
+	rm -rf Module.markers module.order module.sysvers


### PR DESCRIPTION
Replaces SUBDIRS and replaces with M, because [SUBDIRS was removed in the Linux Kernel 5.3](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=7e35b42591c058b91282f95ce3b2cf0c05ffe93d)